### PR TITLE
chore: Add GitHub Actions workflow for publishing drafts on tags

### DIFF
--- a/.github/workflows/release-publish-on-tag.yml
+++ b/.github/workflows/release-publish-on-tag.yml
@@ -1,0 +1,49 @@
+name: Publish Draft (on tag)
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish draft (Release Drafter)
+        uses: release-drafter/release-drafter@v6
+        with:
+          publish: true
+          tag: ${{ github.ref_name }}
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # 2) Nahraj všechny artefakty z dist/ jako assets do právě publikovaného releasu
+      - name: Upload dist assets to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/**
+          fail_on_unmatched_files: true
+          overwrite: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This workflow publishes a draft release when a tag matching 'v*.*.*' is pushed. It includes steps for checking out the code, setting up Node.js, installing dependencies, building the project, and uploading distribution assets.

- [X] Chore

